### PR TITLE
#64910 Set vars to NULL to avoid var undefined warning

### DIFF
--- a/modules/cycling_uk_application_process/src/EventSubscriber/CyclingUkApplicationProcessSubscriber.php
+++ b/modules/cycling_uk_application_process/src/EventSubscriber/CyclingUkApplicationProcessSubscriber.php
@@ -411,6 +411,8 @@ class CyclingUkApplicationProcessSubscriber implements EventSubscriberInterface 
    * @see self::onApplicationStatusChanged
    */
   public function onDynamicsWebformPush(PreDynamicsWebformPush $event) {
+    $machineName = NULL;
+    $applicationType = NULL;
     $webform = $event->getWebform();
     $webform->getHandlers()->has('application_webform_handler')
       && ($handler = $webform->getHandler('application_webform_handler'))


### PR DESCRIPTION
See https://support.agile.coop/cycling-uk/support/php-errors-when-submitting-webform-using-custom-dynamics-webform-handler#comment-278199